### PR TITLE
Update bundler version

### DIFF
--- a/whoapi.gemspec
+++ b/whoapi.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "httparty", "~> 0.13.7"
-  spec.add_development_dependency "bundler", ">= 2.2.33"  
+  spec.add_development_dependency "bundler", ">= 2.2.33"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 1.22"

--- a/whoapi.gemspec
+++ b/whoapi.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "httparty", "~> 0.13.7"
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", ">= 2.2.33"  
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 1.22"


### PR DESCRIPTION
# Overview

Update the Bundler version to `2.2.33` following this alert: https://github.com/WhoAPI/whoapi-ruby/security/dependabot/6.